### PR TITLE
feat: Replace managed_policy_arns to aws_iam_role_policy_attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ No modules.
 |------|------|
 | [aws_iam_openid_connect_provider.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_openid_connect_provider.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_openid_connect_provider) | data source |
 | [aws_iam_policy_document.this_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [tls_certificate.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |

--- a/main.tf
+++ b/main.tf
@@ -62,11 +62,32 @@ data "aws_iam_policy_document" "this_assume_role_policy" {
 }
 
 resource "aws_iam_role" "this" {
-  for_each            = var.iam_roles
-  name                = each.key
-  assume_role_policy  = data.aws_iam_policy_document.this_assume_role_policy[each.key].json
-  managed_policy_arns = each.value.policy_arns
+  for_each           = var.iam_roles
+  name               = each.key
+  assume_role_policy = data.aws_iam_policy_document.this_assume_role_policy[each.key].json
   tags = merge(var.tags, {
     Name = each.key
   })
+}
+
+locals {
+  aws_iam_role_policy_attachment_list = flatten([
+    for k, v in var.iam_roles : [
+      for policy_arn in v.policy_arns : {
+        role_name  = k
+        policy_arn = policy_arn
+      }
+    ]
+  ])
+  aws_iam_role_policy_attachment_map = {
+    for v in local.aws_iam_role_policy_attachment_list : "${v.role_name}/${v.policy_arn}" => v
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  depends_on = [aws_iam_role.this]
+  for_each   = local.aws_iam_role_policy_attachment_map
+
+  role       = each.value.role_name
+  policy_arn = each.value.policy_arn
 }


### PR DESCRIPTION
ref

```
# https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md

5.72.0 (October 15, 2024)
resource/aws_iam_role: The managed_policy_arns argument is deprecated. Use the aws_iam_role_policy_attachments_exclusive resource instead. (#39718)
```